### PR TITLE
Fix PowerVR page faults when resizing windows

### DIFF
--- a/dri3_ws.h
+++ b/dri3_ws.h
@@ -103,4 +103,6 @@ struct driws_drawable {
 	enum driws_drawable_type drawable_type;
 
 	xcb_special_event_t* special_ev;
+
+	bool size_changed;
 };


### PR DESCRIPTION
This fixes two issues that were causing GPU page faults:

 - attempting to change drawable parameters 'in-flight' doesn't seem to work, based on [another WSEGL plugin](https://github.com/rawoul/intelce-wayland/blob/58018113de0233dc1417f1c11dff0f1ba7d72008/egl/wsegl/wayland-wsegl.c#L674) WSEGL_BAD_DRAWABLE must be returned on resize to create a fresh drawable
 - widths are rounded up to the nearest multiple of four (I guess that an internal bus is 128-bit wide so 32-bit alignment is illegal)

There are still two remaining issues:
 - ~~resizes now cause the following, probably harmless, messages to be printed:~~ fixed in the most recent force-push which detects resizes differently
```
PVR:(Error): KEGLGetDrawableParameters: Can't get drawable params [0, ]
PVR:(Error): PrepareToDraw: Invalid drawable [0, ]
PVR:(Error): glDrawElements: Can't prepare to draw [0, ]
```
- repeatedly resizing a window seems to reduce performance and increase the CPU usage of both X11 and the target application. This might be an X11 bug, but unfortunately I haven't got the modesetting driver working yet to compare.