### PR TITLE
Fix accidentally closing fd 0

### DIFF
--- a/dri3_ws.c
+++ b/dri3_ws.c
@@ -299,14 +299,13 @@ static void destroy_buffer(struct driws_buffer *buffer)
 	buffer->pvr_meminfo = NULL;
 
 	close(buffer->dmabuf_fd);
-	buffer->dmabuf_fd = 0;
+	buffer->dmabuf_fd = -1;
 
 #ifdef DRI3WS_USE_GBM
 	gbm_bo_destroy(buffer->gbm_bo);
 #endif
 
 #ifdef DRI3WS_USE_DUMB
-	close(buffer->dmabuf_fd);
 
 	struct drm_mode_destroy_dumb dreq = { 0 };
 	dreq.handle = buffer->drm_handle;


### PR DESCRIPTION
This was causing anything that ended up using fd 0 for genuine purposes to fail in various odd ways (I noticed it with RetroArch, where when it launches a core fd 0 ends up being the sgx device itself).